### PR TITLE
upgrade support

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ var declExpander = function(decl) {
       position;
 
   // Throw decl values into an array
-  var re = /(([\+\-]?[0-9\.]+)(%|px|pt|em|in|cm|mm|ex|pc|vw)?)|(calc\(([^\)]+)\)|null|false|undefined|auto)/g,
+  var re = /(([\+\-]?[0-9\.]+)(%|px|pt|em|rem|in|cm|mm|ex|pc|vw)?)|(calc\(([^\)]+)\)|null|false|undefined|auto)/g,
     m = void 0;
 
   while ((m = re.exec(decl.value)) !== null) {

--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ var declExpander = function(decl) {
   }
 
   // Strip position from vals and store for safe keeping
-  position = decl.value.match(/^static|absolute|fixed|relative|sticky|initial|inherit/).toString();
+  position = decl.value.match(/^static|absolute|fixed|relative|sticky|-webkit-sticky|initial|inherit/).toString();
 
   // Transform input values into correct 4 outputs
   outputVals = (function(ins) {
@@ -89,7 +89,7 @@ module.exports = postcss.plugin('postcss-position', function () {
         declExpander(decl);
       }
 
-      if (decl.prop.match(/^(static|absolute|fixed|relative|sticky|initial|inherit)$/)) {
+      if (decl.prop.match(/^(static|absolute|fixed|relative|sticky|-webkit-sticky|initial|inherit)$/)) {
         result.warn('This syntax is no longer supported, use position: type [offsets]; instead', { node: decl });
       }
 

--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ var declExpander = function(decl) {
   }
 
   // Strip position from vals and store for safe keeping
-  position = decl.value.match(/^static|absolute|fixed|relative|initial|inherit/).toString();
+  position = decl.value.match(/^static|absolute|fixed|relative|sticky|initial|inherit/).toString();
 
   // Transform input values into correct 4 outputs
   outputVals = (function(ins) {
@@ -89,7 +89,7 @@ module.exports = postcss.plugin('postcss-position', function () {
         declExpander(decl);
       }
 
-      if (decl.prop.match(/^(static|absolute|fixed|relative|initial|inherit)$/)) {
+      if (decl.prop.match(/^(static|absolute|fixed|relative|sticky|initial|inherit)$/)) {
         result.warn('This syntax is no longer supported, use position: type [offsets]; instead', { node: decl });
       }
 

--- a/test/test.js
+++ b/test/test.js
@@ -47,6 +47,11 @@ describe('postcss-position', function () {
          'a{ position: absolute; top: calc(100vh - 10px); }', { }, done);
   });
 
+  it('handles rem units', function (done) {
+    test('a{ position: absolute false 2rem 2rem false; }',
+         'a{ position: absolute; right: 2rem; bottom: 2rem; }', { }, done);
+  });
+
   describe('falsey removes', function() {
      it('offsets with false are skipped', function (done) {
         test('a{ position: absolute 10px false 30px false; }',

--- a/test/test.js
+++ b/test/test.js
@@ -52,6 +52,11 @@ describe('postcss-position', function () {
          'a{ position: absolute; right: 2rem; bottom: 2rem; }', { }, done);
   });
 
+  it('handles sticky positioning', function (done) {
+    test('a{ position: sticky 1rem false false false; }',
+         'a{ position: sticky; top: 1rem; }', { }, done);
+  });
+
   describe('falsey removes', function() {
      it('offsets with false are skipped', function (done) {
         test('a{ position: absolute 10px false 30px false; }',


### PR DESCRIPTION
- add `rem` unit support
- add `sticky` positioning support

-------
I've been using `rucksack-css` for a while and in the last couple days noticed that those two definitions weren't supported by the plugin; for `rem` it returns the value with empty unit (i.e. `2rem` -> `2`) and for sticky it returns an error with [`toString`](https://github.com/seaneking/postcss-position/blob/master/index.js#L37) position stripping.

I also added the `-webkit-sticky` support manually to solve issues with autoprefixing.